### PR TITLE
README.md spelling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A common lisp project for generating template projects that use sbcl and buildap
 
 See https://github.com/triclops200/quickapp-cli for the command line standalone utility.
 
-# Exmaple usage
+# Example usage
 ```lisp
 (ql:quickload :quickapp)
 (quickapp:quickapp


### PR DESCRIPTION
Spelling correction in the first heading ("Example usage".)
